### PR TITLE
fix: add margin-bottom to Song Page for better spacing

### DIFF
--- a/src/pages/pages.scss
+++ b/src/pages/pages.scss
@@ -193,6 +193,7 @@
 
 .song {
     margin-top: 85px;
+    margin-bottom: 85px;
     min-height: 100vh;
     padding: 0 20px;
     display: flex;


### PR DESCRIPTION
Added margin-bottom: 85px to .song class to provide consistent vertical spacing on the Song Page.

This change:
- Matches the existing margin-top of 85px
- Follows the consistent spacing pattern used throughout the project
- Improves visual layout and addresses spacing concerns

Fixes #8

Generated with [Claude Code](https://claude.ai/code)